### PR TITLE
bug/fix-wishlist-all-message

### DIFF
--- a/a_messaging/templates/messaging/inbox.html
+++ b/a_messaging/templates/messaging/inbox.html
@@ -11,6 +11,12 @@
                         <div class="font-semibold flex items-center gap-2">
                             {% if c.convo.item %}
                                 {{ c.convo.item.name }}
+                            {% elif c.convo.collectibles.all %}
+                                Wishlist Offer
+                                <span class="badge badge-outline badge-sm ml-2">{{ c.convo.collectibles.count }} items</span>
+                                <span class="tooltip tooltip-bottom ml-1" data-tip="{% for col in c.convo.collectibles.all|slice:':5' %}{{ col.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% if c.convo.collectibles.count > 5 %}, ...{% endif %}">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline-block text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none"/><text x="12" y="16" text-anchor="middle" font-size="12" fill="currentColor">i</text></svg>
+                                </span>
                             {% else %}
                                 General Conversation
                             {% endif %}

--- a/a_messaging/views.py
+++ b/a_messaging/views.py
@@ -64,6 +64,9 @@ def conversation_detail(
     else:
         conversation = get_object_or_404(Conversation, pk=pk, participants=request.user)
         item = conversation.item if conversation.item else None
+    # Wishlist offer support
+    collectibles = conversation.collectibles.all() if conversation.collectibles.exists() else None
+    collectibles_total = sum(c.price for c in collectibles) if collectibles else None
     messages = (
         Message.objects.filter(conversation=conversation)
         .select_related("sender")
@@ -92,6 +95,8 @@ def conversation_detail(
             "form": form,
             "unread_count": unread_count,
             "item": item,
+            "collectibles": collectibles,
+            "collectibles_total": collectibles_total,
         },
     )
 

--- a/agent_changelog.md
+++ b/agent_changelog.md
@@ -1,5 +1,11 @@
 # Agent Changelog
 
+## 2025-06-24 - Dark Mode Toggle Improvements
+
+- Added a dark mode toggle switch to the navbar using DaisyUI's swap/rotate and persisted the user's theme choice with localStorage.
+- Updated the toggle to use a classic outlined sun for light mode and a filled crescent moon for dark mode, based on user feedback for better clarity and aesthetics.
+- Ensured all changes were limited to `nav.html` to avoid breaking other templates.
+
 ## 2025-06-23 - Wishlist, Offer, and Profile Cleanup
 
 - Removed the "My Wishlist" tab and all supporting backend code from the user profile page for a cleaner UX

--- a/agent_changelog.md
+++ b/agent_changelog.md
@@ -240,3 +240,9 @@
 - Added a "Add New Category" field to the collectible create/update form. Users can now enter a new category name directly on the form; it will be created and added to the collectible automatically.
 - Made the categories field optional in the collectible form.
 - Updated the collectible detail page to display all categories as badges. If no categories are set, it shows "None".
+
+## 2025-06-24 - Wishlist Offer Conversation Improvements
+
+- Updated the messaging inbox so that conversations created from a wishlist offer now display as "Wishlist Offer" with a badge showing the number of items and a tooltip preview of up to 5 item names, instead of the generic "General Conversation" label.
+- When viewing a wishlist offer conversation, the item summary (with images, names, and total) is always shown at the top, matching the initial offer view, even when accessed from the inbox.
+- These changes keep the UI clean and informative, even for large wishlists, and provide a consistent experience for wishlist-based conversations.

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -1,6 +1,15 @@
 <div class="navbar bg-base-100 shadow-sm">
   <a href="/collectibles" class="btn btn-ghost text-xl">Collectibles Hub</a>
   <div class="ml-auto flex items-center gap-2">
+    <!-- Dark mode toggle -->
+    <label class="swap swap-rotate mr-2">
+      <input id="theme-toggle" type="checkbox" />
+      <!-- Moon icon for dark mode -->
+      <svg class="swap-on fill-current w-7 h-7" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 0 1 11.21 3a1 1 0 0 0-1.21 1.21A7 7 0 1 0 19.79 13a1 1 0 0 0 1.21-1.21Z"/></svg>
+      <!-- Sun icon for light mode -->
+      <svg class="swap-off fill-current w-7 h-7" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2" fill="none"/><path stroke="currentColor" stroke-width="2" d="M12 1v2m0 18v2m11-11h-2M3 12H1m16.95 7.07-1.41-1.41M6.34 6.34 4.93 4.93m12.02 0-1.41 1.41M6.34 17.66l-1.41 1.41" fill="none"/></svg>
+    </label>
+    <!-- End dark mode toggle -->
     {% if user.is_authenticated %}
       <div id="wishlist-count-container">
         {% include "partials/wishlist_count.html" %}
@@ -28,3 +37,26 @@
     {% endif %}
   </div>
 </div>
+
+<script>
+  // Theme toggle script
+  const themeToggle = document.getElementById('theme-toggle');
+  themeToggle.addEventListener('change', () => {
+    if (themeToggle.checked) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+      localStorage.setItem('theme', 'light');
+    }
+  });
+
+  // Load theme from localStorage
+  const currentTheme = localStorage.getItem('theme');
+  if (currentTheme) {
+    document.documentElement.setAttribute('data-theme', currentTheme);
+    if (currentTheme === 'dark') {
+      themeToggle.checked = true;
+    }
+  }
+</script>


### PR DESCRIPTION
This pull request introduces two major improvements: support for wishlist offer conversations in the messaging system and a dark mode toggle in the navigation bar. These changes enhance the user experience by making conversations more informative and the interface more customizable. Below is a breakdown of the key changes:

### Wishlist Offer Conversation Enhancements:
* Updated the messaging inbox to display conversations created from wishlist offers as "Wishlist Offer" with a badge showing the number of items and a tooltip preview of up to 5 item names. This replaces the generic "General Conversation" label. (`a_messaging/templates/messaging/inbox.html`)
* Added backend support to fetch and calculate wishlist offer details, including the total price of collectibles, for display in the conversation detail view. (`a_messaging/views.py`) [[1]](diffhunk://#diff-8491640fea680ae618157c3b322fb0baa8f0089dc4cb8e593134004f69fe16a2R67-R69) [[2]](diffhunk://#diff-8491640fea680ae618157c3b322fb0baa8f0089dc4cb8e593134004f69fe16a2R98-R99)
* Documented these changes in the changelog under "Wishlist Offer Conversation Improvements." (`agent_changelog.md`)

### Dark Mode Toggle:
* Added a dark mode toggle switch to the navigation bar using DaisyUI's swap/rotate component. The toggle switches between a sun icon for light mode and a moon icon for dark mode. (`templates/nav.html`)
* Implemented a script to persist the user's theme choice using `localStorage` and to load the theme on page load. (`templates/nav.html`)
* Documented these changes in the changelog under "Dark Mode Toggle Improvements." (`agent_changelog.md`)