### PR TITLE
feature/limit-file-size

### DIFF
--- a/a_collectibles/models.py
+++ b/a_collectibles/models.py
@@ -1,8 +1,6 @@
 # Assuming users can own/sell collectibles
 from django.contrib.auth.models import User
 from django.db import models
-from django.db.models.signals import post_migrate
-from django.dispatch import receiver
 
 
 class Category(models.Model):

--- a/agent_changelog.md
+++ b/agent_changelog.md
@@ -1,5 +1,12 @@
 # Agent Changelog
 
+## 2025-06-25 - Client-side Image Compression for Collectibles
+
+- Installed `browser-image-compression` via npm and imported it in `static/js/main.js`.
+- Implemented client-side image compression for all forms with an input named `images`.
+- Images larger than 2MB are automatically compressed in the browser before upload, greatly speeding up uploads and reducing server/S3 load.
+- No backend changes required; works transparently for all collectible image uploads and updates.
+
 ## 2025-06-24 - Dark Mode Toggle Improvements
 
 - Added a dark mode toggle switch to the navbar using DaisyUI's swap/rotate and persisted the user's theme choice with localStorage.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
+    "browser-image-compression": "^2.0.2",
     "htmx.org": "^2.0.4",
     "tailwindcss": "^4.1.10"
   }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,6 +1,51 @@
 import '@/css/main.css';
 import htmx from 'htmx.org';
+import imageCompression from 'browser-image-compression';
 
 
 // Make HTMX available globally
 window.htmx = htmx;
+
+// Client-side image compression for file inputs named 'images'
+document.addEventListener('DOMContentLoaded', () => {
+  const forms = document.querySelectorAll('form');
+  forms.forEach(form => {
+    form.addEventListener('submit', async (e) => {
+      // Only process forms with file input named 'images'
+      const fileInputs = form.querySelectorAll('input[type="file"][name="images"]');
+      if (!fileInputs.length) return;
+      let changed = false;
+      for (const input of fileInputs) {
+        if (!input.files || !input.files.length) continue;
+        const files = Array.from(input.files);
+        const compressedFiles = [];
+        for (const file of files) {
+          // Only compress if >2MB
+          if (file.size > 2 * 1024 * 1024) {
+            try {
+              const compressed = await imageCompression(file, {
+                maxSizeMB: 2,
+                maxWidthOrHeight: 3000, // optional, limit pixel size
+                useWebWorker: true,
+                initialQuality: 0.7,
+              });
+              compressedFiles.push(compressed);
+              changed = true;
+            } catch (err) {
+              console.error('Image compression failed:', err);
+              compressedFiles.push(file); // fallback to original
+            }
+          } else {
+            compressedFiles.push(file);
+          }
+        }
+        if (changed) {
+          // Replace FileList with new DataTransfer
+          const dt = new DataTransfer();
+          compressedFiles.forEach(f => dt.items.add(f));
+          input.files = dt.files;
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces client-side image compression for collectible uploads, removes unused imports in the `a_collectibles` app, and updates dependencies to include the `browser-image-compression` library. These changes aim to improve user experience by speeding up image uploads and reducing server load, while also cleaning up the codebase.

### Client-side Image Compression:

* [`static/js/main.js`](diffhunk://#diff-431ce3d3e025bfd0726c39bbfa7bea8c5b29e7b1df9e8a8b19ed4769d98c5d61R3-R51): Added functionality to compress images larger than 2MB directly in the browser before upload. This applies to file inputs named `images` and uses the `browser-image-compression` library. The compression reduces file size while maintaining quality, improving upload speed and reducing server/S3 load.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20): Added `browser-image-compression` as a new dependency to enable the client-side image compression feature.

### Documentation Updates:

* [`agent_changelog.md`](diffhunk://#diff-deb3739c7e5aeac353e654ebe2fd8a51cbff3f52f84788002b296865dd7a005eR3-R9): Documented the addition of client-side image compression, including the benefits and implementation details.

### Code Cleanup:

* [`a_collectibles/models.py`](diffhunk://#diff-0e665accbb169cf1dedcb935a1f7f5fd367d05a27f9637187af289a23deffc62L4-L5): Removed unused imports (`post_migrate` and `receiver`) to clean up the codebase.- Installed `browser-image-compression` via npm and imported it in `static/js/main.js`.
- Implemented client-side image compression for all forms with an input named `images`.
- Images larger than 2MB are automatically compressed in the browser before upload, greatly speeding up uploads and reducing server/S3 load.
- No backend changes required; works transparently for all collectible image uploads and updates.